### PR TITLE
Support Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,7 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.0"
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 4.0" FACTER_GEM_VERSION="~> 2.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 4.0" FACTER_GEM_VERSION="~> 2.0"
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Currently the only provider is to import RPM GPG keys.
 
 ## Compatibility
 
-| Puppet Versions   | < 2.6 | 2.6 | 2.7     | 3.x     |
-|:-----------------:|:-----:|:---:|:-------:|:-------:|
-| **gpg_key 0.0.x** | no    | no  | **yes** | **yes** |
+| Puppet Versions   | < 2.6 | 2.6 | 2.7     | 3.x     | 4.x     |
+|:-----------------:|:-----:|:---:|:-------:|:-------:|:-------:|
+| **gpg_key 0.0.x** | no    | no  | **yes** | **yes** | **yes** |
 
 ## Support
 


### PR DESCRIPTION
The new Puppet v4 AIO will use Ruby 2.3.1