### PR TITLE
gpg_key: refactor keyid so that the module works under CentOS 8

### DIFF
--- a/lib/puppet/provider/gpg_key/rpm.rb
+++ b/lib/puppet/provider/gpg_key/rpm.rb
@@ -38,7 +38,11 @@ Puppet::Type.type(:gpg_key).provide(:rpm) do
 
   def keyid
     if File.exist?(@resource[:path])
-      gpg(["--quiet", "--throw-keyids", @resource[:path]].compact)[11..18].downcase
+      gpg(["--quiet", "--throw-keyids", "--with-colons", @resource[:path]].compact)
+          .split('\n')
+          .find {|item| item.start_with?("pub:")}
+          .split(':')[4][8..15]
+          .downcase
     else
       nil
     end


### PR DESCRIPTION
Source of the problem:
The output of the gpg command changed from version 2.0 to 2.2.

Refactoring:
Run the gpg command with one additional option (--with-colons) and extract
the key id from the first line starting with the pattern 'pub:'.

Tested on CentOS 7 (with gnupg 2.0) and on CentOS 8 (with gnupg 2.2).